### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/source/isotp/examples.rst
+++ b/doc/source/isotp/examples.rst
@@ -139,7 +139,7 @@ Sending with functional addressing (broadcast)
 Defining custom rxfn and txfn
 -----------------------------
 
-In this example, we see how to configure a :class:`TransportLayer<isotp.TransportLayer>` to interract with a hardware different than python-can with a fictive API.
+In this example, we see how to configure a :class:`TransportLayer<isotp.TransportLayer>` to interact with a hardware different than python-can with a fictive API.
 
 .. code-block:: python
 

--- a/isotp/tpsock/__init__.py
+++ b/isotp/tpsock/__init__.py
@@ -117,7 +117,7 @@ class socket:
     def bind(self, interface, *args, **kwargs):
         """
         Binds the socket to an address. 
-        If no address is provided, all additional parameters will be used to create an adresse. This is mainly to allow a syntax such as ``sock.bind('vcan0', rxid=0x123, txid=0x456)`` for backward compatibility.
+        If no address is provided, all additional parameters will be used to create an address. This is mainly to allow a syntax such as ``sock.bind('vcan0', rxid=0x123, txid=0x456)`` for backward compatibility.
 
         :param interface: The network interface to use
         :type interface: string


### PR DESCRIPTION
This fixes various typos found in the documentation:

  * interract -> interact
  * adresse -> address