### PR TITLE
Add stack sleep timing attributes

### DIFF
--- a/isotp/protocol.py
+++ b/isotp/protocol.py
@@ -375,9 +375,6 @@ class TransportLayer:
             (self.RxState.IDLE, self.TxState.WAIT_FC) 	: 0.01,
         }
 
-        self.idle_sleep = 0.05                  # Default
-        self.wait_fc_sleep = 0.01
-
     def send(self, data, target_address_type=isotp.address.TargetAddressType.Physical):
         """
         Enqueue an IsoTP frame to be sent over CAN network


### PR DESCRIPTION
Due to an application I have been working on, the strict P2 timing requirement of 50ms causes an issue with the isotp stack due to insufficient granularity. The stack's default thread timing is 0.05 for IDLE and 0.01 for FC. To meet P2 timing requirements with sufficient granularity, the timing is required to be reduced. Otherwise there will be constant P2 timeouts. 

This PR presents a fix by adding a settable sleep timing attribute called 'timings' in the TransportLayer Class. If the attribute is not modified by calling `set_sleep_timing`, it defaults to the current values of 0.05 for IDLE and 0.01 for FC.