### PR TITLE
Fix calculation of ISO-TP SF size field length

### DIFF
--- a/isotp/protocol.py
+++ b/isotp/protocol.py
@@ -618,7 +618,7 @@ class TransportLayer:
                         read_tx_queue = True	# Read another frame from tx_queue
                     else:
                         self.tx_buffer = bytearray(popped_object['data'])
-                        size_on_first_byte = True if len(self.tx_buffer) <= 7 else False
+                        size_on_first_byte = (len(self.tx_buffer) + len(self.address.tx_payload_prefix)) <= 7
                         size_offset = 1 if size_on_first_byte else 2
 
                         # Single frame

--- a/test/test_addressing_modes.py
+++ b/test/test_addressing_modes.py
@@ -423,6 +423,20 @@ class TestAddressingMode(TransportLayerBaseTest):
             layer.send(b'\x55' * 30, functional)
         layer.params.set('tx_data_length', 8)
 
+        # Transmit single frame with payload length 7 - Physical; txdl=16...64
+        for tx_len in (12, 16, 20, 24, 32, 48, 64):
+            layer.reset()
+            layer.params.set("tx_data_length", tx_len)
+            layer.send(b'\x55' * 7)
+            layer.process()
+
+            msg = self.get_tx_can_msg()
+            self.assertIsNotNone(msg)
+            self.assertEqual(msg.arbitration_id, txid)
+            self.assertEqual(msg.data, bytearray([ta, 0x00, 0x07] + [0x55] * 7 + [0xCC] * 2))
+            self.assertFalse(msg.is_extended_id)
+        layer.params.set("tx_data_length", 8)
+
         # Transmit multiframe - Physical
         layer.reset()
         layer.send(b'\x04\x05\x06\x07\x08\x09\x0A\x0B', physical)


### PR DESCRIPTION
Given the following setup:
* CAN-FD bus
* tx_data_length = 64
* extended addressing

When sending a 7 byte payload, the full ISO-TP frame with size and address fields would have a minimum size of `7 (data) + 1 (addr) + 1 (header + size field) = 9`. According to the standard, when receiving a CAN frame with a data length of >8 byte, the size field must have a length of 12 bit and the first four bits must be equal to 0. However, the current implementation does not correctly calculate the length of the size field and uses only four bits.

In the patch, I updated the size field length calculation to what I would assume to be correct. I also added a unit test to verify the correct behavior.