### PR TITLE
Listener/Notifier Substitution

### DIFF
--- a/isotp/protocol.py
+++ b/isotp/protocol.py
@@ -61,7 +61,6 @@ class PDU:
         Overflow = 2
 
     def __init__(self, msg = None, start_of_data=0):
-
         self.type = None
         self.length = None
         self.data = None
@@ -569,7 +568,7 @@ class TransportLayer:
         self.tx_queue.put({'data':data, 'target_address_type':target_address_type})	# frame is always an IsoTPFrame here
 
     # Receive an IsoTP frame. Output of the layer
-    def recv(self,block=True,timeout=None):
+    def recv(self):
         """
         Dequeue an IsoTP frame from the reception queue if available.
 
@@ -1153,7 +1152,6 @@ class CanStack(TransportLayer):
             :param timeout: The number of seconds to wait for a new message.
             :return: the received :class:`can.Message` or `None`, if the queue is empty.
             """
-
             try:
                 # if self.is_stopped:
                 return self.buffer.get(block=False)


### PR DESCRIPTION
- substitue bus.recv() by using Notifier/Listener get_message() method 
(note: by using this change, set_sleep_timing(0, 0) will not make your program most quick, for me x=y=1e-6 has the best performance using python3.11.5 on CPU: i5-1145G7, I do not know why, need investigate)
- Remove not useful lines.

Maybe the implement is not graceful enough, please figure out.