### PR TITLE
Improve NotifierBasedCanStack handling of error and remote frames

### DIFF
--- a/isotp/protocol.py
+++ b/isotp/protocol.py
@@ -1808,14 +1808,20 @@ class NotifierBasedCanStack(TransportLayer, BusOwner):
 
     def start(self) -> None:
         self.buffered_reader = can.BufferedReader()
-        self.notifier.add_listener(self.buffered_reader)
+        self.notifier.add_listener(self._on_message_received)
         super().start()
 
     def stop(self) -> None:
         try:
             if self.buffered_reader is not None:
-                self.notifier.remove_listener(self.buffered_reader)
+                self.notifier.remove_listener(self._on_message_received)
         except Exception:
             pass
         self.buffered_reader = None
         super().stop()
+
+    def _on_message_received(self, msg: can.Message) -> None:
+        if msg.is_error_frame or msg.is_remote_frame:
+            return
+        if self.buffered_reader is not None:
+            self.buffered_reader.on_message_received(msg)

--- a/isotp/protocol.py
+++ b/isotp/protocol.py
@@ -1820,7 +1820,7 @@ class NotifierBasedCanStack(TransportLayer, BusOwner):
         self.buffered_reader = None
         super().stop()
 
-    def _on_message_received(self, msg: can.Message) -> None:
+    def _on_message_received(self, msg: "can.Message") -> None:
         if msg.is_error_frame or msg.is_remote_frame:
             return
         if self.buffered_reader is not None:

--- a/test/test_can_stack.py
+++ b/test/test_can_stack.py
@@ -131,6 +131,18 @@ class TestCanStackNotifier(unittest.TestCase):
         self.assertEqual(data, payload)
         self.assert_no_error_reported()
 
+    def test_1000_error_frames(self):
+        error_frame = can.Message(arbitration_id=0x8, is_extended_id=False, is_error_frame=True,
+                                  data=[0x0, 0x19, 0x81, 0x0])
+        for i in range(1000):
+            self.bus.send(error_frame)
+
+        payload = bytearray([x & 0xFF for x in range(5)])
+        self.layer1.send(payload)
+        data = self.layer2.recv(block=True, timeout=3)
+        self.assertEqual(data, payload)
+        self.assert_no_error_reported()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves https://github.com/pylessard/python-can-isotp/issues/142 by inspecting incoming frames from the notifier and throwing away error frames and remote frames.

Adds a test to replicate the problem reported on https://github.com/pylessard/python-can-isotp/issues/142.


